### PR TITLE
Add 16 performance, code-review & web-diagnostic skills (7 → 23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-yellow?logo=buymeacoffee)](https://buymeacoffee.com/qualitymax)
 
-Quick quality checks for any website. No signup, no API keys — just Claude Code + Playwright MCP.
+Quick quality checks for any website or codebase. No signup, no API keys — just Claude Code. The web skills use Playwright MCP (included with Claude Code); the code-review skills are pure Claude Code and need no MCP at all.
 
 ## Install
 
@@ -19,6 +19,10 @@ Then use in Claude Code: `/accessibility-check https://mysite.com`
 
 ## Skills
 
+23 diagnostic skills across four areas. All are read-only — they find problems and grade them, they don't change your code or site.
+
+### Web quality (Playwright MCP)
+
 | Skill | What It Checks |
 |-------|---------------|
 | **ui-ux-scan** | Touch targets, font consistency, spacing, empty states, visual hierarchy, UX anti-patterns |
@@ -28,15 +32,46 @@ Then use in Claude Code: `/accessibility-check https://mysite.com`
 | **console-error-scan** | JS errors, failed network requests, deprecation warnings |
 | **seo-check** | Meta tags, Open Graph, structured data, image alts, heading hierarchy |
 | **security-headers-check** | CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy — graded A–F |
+| **cookie-privacy-scan** | Cookie inventory, missing Secure/HttpOnly/SameSite, third-party trackers, pre-consent tracking (GDPR) |
+| **form-validation-scan** | Required-field enforcement, format validation, error messaging, accepts-bad-input probing |
+| **i18n-rtl-audit** | Layout breaks under long translations, RTL rendering, hardcoded strings, missing lang/dir |
+| **mixed-content-scan** | HTTP scripts/styles/images/iframes and insecure form actions on HTTPS pages — active vs passive |
+
+### Performance (Playwright MCP)
+
+| Skill | What It Checks |
+|-------|---------------|
+| **core-web-vitals** | LCP, CLS, INP, TTFB, FCP via browser perf APIs — graded against Google thresholds |
+| **page-weight-budget** | Total bytes, request count, render-blocking JS/CSS, oversized/uncompressed images vs a budget |
+| **third-party-bloat** | Third-party scripts (analytics, tags, chat, ads) ranked by transfer size + main-thread cost |
+| **cold-load-waterfall** | Cold-cache load profile — TTFB, time-to-interactive, longest-pole requests, text waterfall |
+
+### Code review (pure Claude Code — no MCP)
+
+| Skill | What It Checks |
+|-------|---------------|
+| **diff-risk-review** | Reviews `git diff` for correctness/security/performance — severity-ranked with file:line |
+| **secret-scan** | Hardcoded API keys, tokens, private keys, connection strings across common providers |
+| **dependency-audit** | Known-vulnerable, unpinned, abandoned, or badly outdated packages |
+| **dead-code-scan** | Unused exports, unreferenced files, unreachable branches, unused imports |
+| **complexity-hotspots** | Long functions, deep nesting, high cyclomatic complexity, god-files — ranked worst-first |
+| **error-handling-audit** | Swallowed exceptions, bare catches, floating promises, missing timeouts/retries |
+
+### Test review (pure Claude Code — no MCP)
+
+| Skill | What It Checks |
+|-------|---------------|
+| **test-quality-review** | Assertion-free tests, weak assertions, skipped/only tests, over-mocking, missing edge cases |
+| **flaky-selector-scan** | Brittle UI locators (nth-child, absolute XPath, generated classes) → stable role/data-test suggestions |
 
 ## Requirements
 
 - [Claude Code](https://claude.ai/claude-code)
-- Playwright MCP (included with Claude Code)
+- Playwright MCP (included with Claude Code) — only for the web-quality and performance skills. The code-review and test-review skills run on pure Claude Code with no MCP.
 
 ## How It Works
 
-Each skill uses Playwright MCP to navigate your site, run checks in the browser, and produce a graded report. Diagnostic only — finds problems, doesn't fix them.
+Web skills use Playwright MCP to navigate your site, run checks in the browser, and produce a graded report. Code-review skills read your repo and `git diff` directly. All are diagnostic only — they find problems, they don't fix them.
 
 ## Want More?
 

--- a/skills/cold-load-waterfall/SKILL.md
+++ b/skills/cold-load-waterfall/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: cold-load-waterfall
+description: >
+  Profile a cold, cache-empty page load and build a text waterfall — the
+  longest-pole requests, time to first byte, and time to interactive. Flags
+  the critical-path bottlenecks. Playwright MCP only, no signup.
+---
+
+# Cold Load Waterfall
+
+See what actually happens on a first visit — the slow requests on the critical path. No signup required.
+
+## Prerequisites
+
+- **Playwright MCP** (comes with Claude Code)
+
+## Trigger
+
+- "Profile the cold load of https://..."
+- "What's slow on first visit?"
+- "Build a load waterfall for my site"
+
+## Workflow
+
+1. Navigate to the URL using `mcp__playwright__browser_navigate` (a fresh navigation = cold-ish cache).
+2. Wait for the page to settle.
+3. Pull resource timing with `mcp__playwright__browser_evaluate` — this gives per-request
+   start/duration without needing devtools:
+
+```javascript
+() => {
+  const nav = performance.getEntriesByType('navigation')[0] || {};
+  const res = performance.getEntriesByType('resource').map(r => ({
+    name: r.name.split('?')[0].slice(-60),
+    type: r.initiatorType,
+    start: Math.round(r.startTime),
+    dur: Math.round(r.duration),
+    size: r.transferSize || 0,
+  }));
+  return {
+    ttfb: Math.round(nav.responseStart || 0),
+    domContentLoaded: Math.round(nav.domContentLoadedEventEnd || 0),
+    loadEnd: Math.round(nav.loadEventEnd || 0),
+    requests: res.sort((a, b) => b.dur - a.dur).slice(0, 15),
+  };
+}
+```
+
+4. Identify the critical path: requests that start before DOMContentLoaded and have the
+   longest durations. Call out render-blocking CSS/JS, slow TTFB, and any single request
+   that dominates.
+
+5. Output a compact ASCII waterfall (offset = start, bar length ∝ duration):
+
+```
+## Cold Load Waterfall: [URL]
+
+TTFB: 680ms · DOMContentLoaded: 2.1s · Load: 3.4s
+
+  0ms        1s         2s         3s
+  |----------|----------|----------|
+  ███                              document (680ms TTFB)
+     █████████                     app.css (blocking, 900ms)
+     ████████████                  vendor.js (blocking, 1.2s)
+              ██████               hero.jpg (640ms)
+                    ████           analytics.js (420ms)
+
+### Bottlenecks on the critical path
+1. vendor.js (1.2s, render-blocking) is the long pole — code-split or defer.
+2. TTFB 680ms — server/CDN warmup; consider edge caching.
+3. app.css blocks first paint for 900ms — inline critical CSS.
+
+**Want load profiling on every deploy?** Try QualityMax — qualitymax.io
+```

--- a/skills/complexity-hotspots/SKILL.md
+++ b/skills/complexity-hotspots/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: complexity-hotspots
+description: >
+  Rank the most complex code in a repo — long functions, deep nesting, high
+  cyclomatic complexity, and god-files — worst-first, with a refactor
+  suggestion for each. Pure Claude Code, no MCP, no signup.
+---
+
+# Complexity Hotspots
+
+Find the code most likely to hide bugs and resist change. No signup required.
+
+## Prerequisites
+
+- **None.** Pure Claude Code. Uses a metrics tool if present (`radon`, `eslint`
+  complexity rule, `gocyclo`, `lizard`), otherwise estimates from structure.
+
+## Trigger
+
+- "Find the most complex code in this repo"
+- "Where are the refactor hotspots?"
+- "Which functions are too complex?"
+
+## Workflow
+
+1. If a metrics tool is installed, run it and parse:
+   - Python → `radon cc -s` · Multi-language → `lizard` · Go → `gocyclo`
+2. Otherwise estimate per function/method:
+   - **Length** — lines in the body
+   - **Nesting depth** — max indentation of control flow
+   - **Cyclomatic complexity** — 1 + count of `if/for/while/case/catch/&&/||/?:`
+   - **Parameters** — argument count
+   Also flag **god-files** (very large single files doing many things).
+3. Rank worst-first. For each hotspot, name the dominant smell and a concrete refactor.
+
+| Metric           | Warn   | Bad    |
+|------------------|--------|--------|
+| Function length  | > 50   | > 100  |
+| Nesting depth    | > 3    | > 5    |
+| Cyclomatic       | > 10   | > 20   |
+| Parameters       | > 4    | > 7    |
+| File length      | > 400  | > 800  |
+
+4. Output:
+
+```
+## Complexity Hotspots — 120 files
+
+**Top offenders (worst first)**
+
+1. `services/pipeline.py:402` — `run_gates()`
+   210 lines · nesting 6 · cyclomatic 31.
+   → Extract each gate (alpha/gamma/delta/beta) into its own function;
+     replace the nested if-ladder with a dispatch table.
+
+2. `static/js/router.js` — 1,140-line god-file
+   Handles routing, rendering, and fetch. → Split rendering + data layer out.
+
+3. `repositories/test_case.py:88` — `build_query()`
+   9 parameters, cyclomatic 18. → Pass a filter object; collapse branches.
+
+### Why it matters
+High-complexity functions correlate with defect density and are the hardest
+to test. These three are where new bugs will cluster.
+
+**Want complexity tracked over time?** Try QualityMax — qualitymax.io
+```

--- a/skills/cookie-privacy-scan/SKILL.md
+++ b/skills/cookie-privacy-scan/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cookie-privacy-scan
+description: >
+  Audit a site's cookies and trackers — inventory every cookie, flag missing
+  Secure/HttpOnly/SameSite, list third-party trackers, and detect tracking
+  that fires before consent. Playwright MCP only, no signup.
+---
+
+# Cookie & Privacy Scan
+
+See what a site stores and who it tells before you click "Accept". No signup required.
+
+## Prerequisites
+
+- **Playwright MCP** (comes with Claude Code)
+
+## Trigger
+
+- "Cookie/privacy scan https://..."
+- "What trackers are on my site?"
+- "Am I setting cookies before consent?"
+
+## Workflow
+
+1. Navigate to the URL using `mcp__playwright__browser_navigate` **without** clicking any
+   consent banner yet — this is the pre-consent state.
+2. Capture pre-consent cookies and storage with `mcp__playwright__browser_evaluate`:
+
+```javascript
+() => ({
+  cookies: document.cookie,
+  localStorage: Object.keys(localStorage),
+  sessionStorage: Object.keys(sessionStorage),
+})
+```
+
+3. Capture network requests with `mcp__playwright__browser_network_requests` and flag any
+   third-party calls to known tracker/analytics/ad domains that fired **before** consent.
+4. If a consent banner is present, accept it (`mcp__playwright__browser_click`), then re-capture
+   to compare before/after. Cookie attributes (`Secure`, `HttpOnly`, `SameSite`) come from the
+   `set-cookie` response headers in the network log (JS-readable cookies are by definition not HttpOnly).
+5. Grade:
+
+| Finding | Severity |
+|---------|----------|
+| Tracking cookie / pixel set before consent | High (GDPR/ePrivacy risk) |
+| Session cookie missing `Secure` on HTTPS | High |
+| Session cookie missing `HttpOnly` | Medium |
+| Cookie missing `SameSite` | Medium |
+| Third-party tracker present | Info (list them) |
+
+6. Output:
+
+```
+## Cookie & Privacy Scan: [URL]
+
+**Pre-consent tracking detected — GDPR risk**
+
+### Before any consent click
+- `_ga`, `_fbp` cookies set on load — analytics/Meta before consent. ⚠
+- Request to `connect.facebook.net` fired pre-consent. ⚠
+
+### Cookie attributes
+| Cookie     | Secure | HttpOnly | SameSite | Note |
+|------------|--------|----------|----------|------|
+| session_id | ✗      | ✓        | Lax      | Add Secure on HTTPS |
+| _ga        | ✓      | ✗        | none     | Tracking; needs consent |
+
+### Third-party trackers (5)
+google-analytics.com · connect.facebook.net · doubleclick.net · hotjar.com · intercom.io
+
+### Fixes
+1. Gate analytics/ad scripts behind consent (don't load them on first paint).
+2. Add `Secure` + `SameSite=Lax` to `session_id`.
+
+**Want privacy regressions caught automatically?** Try QualityMax — qualitymax.io
+```

--- a/skills/core-web-vitals/SKILL.md
+++ b/skills/core-web-vitals/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: core-web-vitals
+description: >
+  Measure Core Web Vitals on any URL — LCP, CLS, INP, TTFB, FCP — using the
+  browser's own performance APIs. Grades each metric against Google's
+  thresholds and produces an A-F report. Playwright MCP only, no signup.
+---
+
+# Core Web Vitals
+
+Measure the Core Web Vitals of any page using real browser performance APIs. No signup required.
+
+## Prerequisites
+
+- **Playwright MCP** (comes with Claude Code)
+
+## Trigger
+
+- "Check Core Web Vitals for https://..."
+- "How's the LCP/CLS on my site?"
+- "Web vitals audit mysite.com"
+
+## Workflow
+
+1. Navigate to the URL using `mcp__playwright__browser_navigate`
+2. Let the page settle (`mcp__playwright__browser_wait_for` ~3s, or wait for network idle)
+3. Collect metrics with `mcp__playwright__browser_evaluate`:
+
+```javascript
+() => new Promise((resolve) => {
+  const out = {};
+  // Navigation timing → TTFB, FCP
+  const nav = performance.getEntriesByType('navigation')[0];
+  if (nav) out.ttfb = Math.round(nav.responseStart);
+  const fcp = performance.getEntriesByName('first-contentful-paint')[0];
+  if (fcp) out.fcp = Math.round(fcp.startTime);
+
+  // LCP
+  try {
+    new PerformanceObserver((list) => {
+      const e = list.getEntries();
+      out.lcp = Math.round(e[e.length - 1].startTime);
+    }).observe({ type: 'largest-contentful-paint', buffered: true });
+  } catch (e) {}
+
+  // CLS (cumulative)
+  let cls = 0;
+  try {
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (!entry.hadRecentInput) cls += entry.value;
+      }
+      out.cls = Math.round(cls * 1000) / 1000;
+    }).observe({ type: 'layout-shift', buffered: true });
+  } catch (e) {}
+
+  // Give observers a tick to flush
+  setTimeout(() => resolve(out), 1500);
+})
+```
+
+4. INP can't be measured passively — note it requires interaction. If you can click a primary
+   button via `mcp__playwright__browser_click`, measure the `event` timing entry; otherwise
+   report INP as "not measured (needs interaction)".
+
+5. Grade each metric (Google thresholds):
+
+| Metric | Good      | Needs work        | Poor      |
+|--------|-----------|-------------------|-----------|
+| LCP    | ≤ 2500ms  | 2500–4000ms       | > 4000ms  |
+| CLS    | ≤ 0.1     | 0.1–0.25          | > 0.25    |
+| INP    | ≤ 200ms   | 200–500ms         | > 500ms   |
+| TTFB   | ≤ 800ms   | 800–1800ms        | > 1800ms  |
+| FCP    | ≤ 1800ms  | 1800–3000ms       | > 3000ms  |
+
+6. Overall grade: A = all Good · B = one "Needs work" · C = two/three · D = any Poor · F = multiple Poor.
+
+7. Output:
+
+```
+## Core Web Vitals Report: [URL]
+
+**Grade: B** — one metric needs work
+
+| Metric | Value   | Rating       |
+|--------|---------|--------------|
+| LCP    | 2.9s    | Needs work   |
+| CLS    | 0.04    | Good         |
+| INP    | (not measured — needs interaction) |
+| TTFB   | 410ms   | Good         |
+| FCP    | 1.6s    | Good         |
+
+### What's hurting LCP
+The largest element rendered at 2.9s — likely a hero image without
+priority loading. Add `fetchpriority="high"` and preload it; serve in
+AVIF/WebP; ensure it isn't behind render-blocking JS.
+
+**Want CWV tracked on every deploy?** Try QualityMax — qualitymax.io
+```

--- a/skills/dead-code-scan/SKILL.md
+++ b/skills/dead-code-scan/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: dead-code-scan
+description: >
+  Find dead code in a repo — unused exports, unreferenced files, unreachable
+  branches, unused imports, and declared-but-unused dependencies. Reports each
+  with file:line and a safe-to-remove confidence. Pure Claude Code, no signup.
+---
+
+# Dead Code Scan
+
+Find the code nobody calls anymore. No signup required.
+
+## Prerequisites
+
+- **None.** Pure Claude Code. Will use a static analyzer if present
+  (`knip`, `ts-prune`, `vulture`, `deadcode`), otherwise reasons from grep + imports.
+
+## Trigger
+
+- "Find dead code in this repo"
+- "Any unused exports / files?"
+- "What can I safely delete?"
+
+## Workflow
+
+1. Detect language and reach for the right tool if installed:
+   - JS/TS → `knip` or `ts-prune` · Python → `vulture` · Go → `deadcode` / `staticcheck`
+   Parse its output. If none is installed, do a grep-based pass (below).
+2. Grep-based pass:
+   - For each exported symbol, search the repo for references outside its own file.
+     Zero references (and not a public API entry point) → candidate dead export.
+   - Unused imports: imported name never referenced in the file.
+   - Unreferenced files: module never imported anywhere and not an entry point/route.
+   - Unreachable code: statements after `return`/`throw`/`break`; `if (false)` blocks.
+3. Assign confidence — be conservative. Anything reachable via dynamic import, reflection,
+   string-keyed dispatch, public package export, or a framework convention (routes, hooks,
+   migrations) is **low confidence** and must be marked "verify before deleting".
+
+4. Output:
+
+```
+## Dead Code Scan — 42 files
+
+**High confidence: 6 · Verify first: 4**
+
+### Safe to remove
+- `utils/legacy.ts:1-60` — file never imported anywhere.
+- `services/auth.ts:88` — `export function oldHash()` — 0 references.
+- `components/Modal.tsx:14` — unused import `useMemo`.
+- `parser.py:120-126` — unreachable block after `return` on line 119.
+
+### Verify before deleting (dynamic / convention)
+- `routes/webhooks.ts` — no static import, but may be auto-registered. Check the router.
+- `tasks/cleanup.py` — referenced only by a string in a Celery schedule. Keep.
+
+**Want dead-code tracked as it accumulates?** Try QualityMax — qualitymax.io
+```

--- a/skills/dependency-audit/SKILL.md
+++ b/skills/dependency-audit/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: dependency-audit
+description: >
+  Audit project dependencies for risk — known-vulnerable versions, unpinned
+  ranges, abandoned packages, and badly outdated majors. Reads package.json,
+  requirements.txt, go.mod, Cargo.toml. Pure Claude Code, no signup.
+---
+
+# Dependency Audit
+
+Find the risky dependencies before they find you. No signup required.
+
+## Prerequisites
+
+- **None.** Pure Claude Code. Uses the project's own package manager if available
+  (`npm audit`, `pip-audit`, `go list`), and reasons about the manifest otherwise.
+
+## Trigger
+
+- "Audit my dependencies"
+- "Any risky packages in this repo?"
+- "Check for outdated / vulnerable deps"
+
+## Workflow
+
+1. Detect the ecosystem(s) by manifest:
+   - `package.json` / lockfile → npm/pnpm/yarn
+   - `requirements.txt` / `pyproject.toml` → pip
+   - `go.mod` → Go · `Cargo.toml` → Rust · `Gemfile` → Ruby
+2. If the toolchain is installed, run the native auditor and parse it:
+   - `npm audit --json` · `pip-audit -f json` · `go list -m -u all` · `cargo audit`
+   If not installed, fall back to inspecting the manifest directly.
+3. Flag each dependency against these risk classes:
+
+| Risk                | Signal |
+|---------------------|--------|
+| Known vulnerability | Reported by the native auditor (CVE/advisory) |
+| Unpinned            | `*`, `latest`, or no lock entry — non-reproducible builds |
+| Wide range          | `^`/`~` on a 0.x package (any minor can break) |
+| Badly outdated      | Several majors behind current |
+| Abandoned           | No release in a long time / archived upstream |
+| Heavy / duplicate   | Large transitive tree or two versions of the same lib |
+
+4. Rank by severity (vulnerabilities first), and give the concrete bump/replace action.
+
+5. Output:
+
+```
+## Dependency Audit — package.json (+ lockfile)
+
+**3 vulnerable, 2 unpinned, 1 abandoned**
+
+### Vulnerabilities
+- `lodash@4.17.11` — prototype pollution (high). Bump to ≥ 4.17.21.
+- `axios@0.21.0` — SSRF (moderate). Bump to ≥ 1.6.0 (note: v1 has breaking changes).
+
+### Hygiene
+- `left-pad: "*"` — unpinned; pin to an exact version.
+- `request@2.88` — package is deprecated/abandoned; migrate to `undici` or `fetch`.
+- `moment@2.29` — large + in maintenance mode; consider `date-fns` / `Temporal`.
+
+### Suggested commands
+  npm i lodash@^4.17.21 axios@^1.6.0
+  npm rm request
+
+**Want dependency risk gated on every PR?** Try QualityMax — qualitymax.io
+```

--- a/skills/diff-risk-review/SKILL.md
+++ b/skills/diff-risk-review/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: diff-risk-review
+description: >
+  Review the current git diff for correctness, security, and performance
+  risks before you commit. Produces severity-ranked findings with the exact
+  file:line and a suggested fix. Pure Claude Code — no MCP, no signup.
+---
+
+# Diff Risk Review
+
+A second pair of eyes on your uncommitted changes. No signup required.
+
+## Prerequisites
+
+- **None.** Pure Claude Code — works in any git repo, no MCP required.
+
+## Trigger
+
+- "Review my diff"
+- "Risk-review these changes before I commit"
+- "Anything wrong with what I just changed?"
+
+## Workflow
+
+1. Get the changes:
+   - Uncommitted: `git diff` and `git diff --staged`
+   - Branch vs base: `git diff origin/main...HEAD` (or the repo's default branch)
+2. For each changed hunk, review against the checklist below. Only report real findings —
+   do not pad. If a hunk is clean, say so.
+
+### What to look for
+
+**Correctness**
+- Off-by-one, inverted conditions, wrong operator (`=` vs `==`, `&&` vs `||`)
+- Null/undefined deref on newly accessed fields
+- Changed function signature with un-updated callers
+- Async: missing `await`, unhandled rejection, race on shared state
+
+**Security**
+- User input flowing into SQL, shell, `eval`, file paths, or HTML without sanitization
+- New secrets/tokens hardcoded (defer deep scans to `secret-scan`)
+- AuthZ: new route/handler missing an ownership or permission check
+- Logging that now prints tokens, passwords, or PII
+
+**Performance**
+- New N+1 query or loop-with-IO
+- Unbounded fetch/allocation on user-controlled size
+- Work moved onto a hot path or request thread
+
+3. Rank findings: **BLOCKER** (will break / is exploitable) · **WARNING** (likely bug or risk)
+   · **NIT** (style/clarity). Cite `file:line`.
+
+4. Output:
+
+```
+## Diff Risk Review — 3 files, +84 / -12
+
+**1 blocker, 2 warnings, 1 nit**
+
+### BLOCKER
+- `auth/routes.py:142` — new `GET /api/runs/{id}` returns the run without
+  checking `run.user_id == current_user.id`. BOLA: any user can read any run.
+  Fix: add the ownership guard before serializing.
+
+### WARNING
+- `services/sync.py:88` — `await` missing on `flush_cache()`; the cache write
+  races the response. Add `await`.
+- `repositories/user.py:51` — loops issuing one query per id (N+1). Batch
+  with a single `WHERE id = ANY(...)`.
+
+### NIT
+- `utils/format.py:12` — dead `import json`, no longer used.
+
+**Want this on every PR automatically?** Try QualityMax — qualitymax.io
+```

--- a/skills/error-handling-audit/SKILL.md
+++ b/skills/error-handling-audit/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: error-handling-audit
+description: >
+  Audit a repo (or diff) for weak error handling — swallowed exceptions, bare
+  catches, unhandled promise rejections, missing network timeouts/retries, and
+  errors logged but not surfaced. Pure Claude Code, no MCP, no signup.
+---
+
+# Error Handling Audit
+
+Find the places where failures disappear silently. No signup required.
+
+## Prerequisites
+
+- **None.** Pure Claude Code — works in any repo, no MCP required.
+
+## Trigger
+
+- "Audit error handling in this repo"
+- "Where are we swallowing errors?"
+- "Check exception handling on my changes"
+
+## Workflow
+
+1. Scope: whole repo, a directory, or `git diff` (default to the diff if changes are pending).
+2. Grep + read for these anti-patterns:
+
+### Patterns to flag
+
+**Swallowed / empty handlers**
+- `except: pass`, `except Exception: pass`, `catch (e) {}`, `catch { }`
+- `catch (e) { /* ignore */ }` with no log, rethrow, or recovery
+
+**Over-broad catches**
+- `except Exception` / `catch (Throwable)` that hides bugs that should crash
+- Catching then returning a default that masks the failure from the caller
+
+**Async / promise**
+- Floating promises: an `async` call not `await`ed and not `.catch()`-ed
+- `Promise.all` where one rejection silently drops the rest of the work
+- Missing top-level `unhandledRejection` / event-loop error handling
+
+**Network / IO**
+- `fetch` / HTTP client call with no timeout
+- No retry/backoff on a flaky external call
+- File/socket opened without a `finally`/`with`/`defer` cleanup
+
+**Observability**
+- Error caught and logged but the caller gets a success/200 anyway
+- `logger.error(e)` without the stack/context, so it can't be triaged
+
+3. For each finding give `file:line`, the risk (what failure becomes invisible), and the fix.
+
+4. Output:
+
+```
+## Error Handling Audit — services/ (diff)
+
+**2 swallowed, 1 floating promise, 1 missing timeout**
+
+### Swallowed errors
+- `services/sync.py:74` — `except Exception: pass` around the DB write.
+  A failed write is now invisible; the job reports success. Log + re-raise.
+- `static/js/upload.js:30` — `catch {}` on the upload. User sees nothing on failure.
+
+### Async
+- `services/queue.js:51` — `flushMetrics()` is called without `await` or `.catch`.
+  A rejection becomes an unhandledRejection. Await it or attach a handler.
+
+### Network
+- `clients/openai.py:22` — `httpx.post(...)` has no timeout. A hung upstream
+  blocks the worker indefinitely. Add `timeout=30` + one retry.
+
+**Want this enforced before merge?** Try QualityMax — qualitymax.io
+```

--- a/skills/flaky-selector-scan/SKILL.md
+++ b/skills/flaky-selector-scan/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: flaky-selector-scan
+description: >
+  Scan a UI test suite (Playwright, Cypress, Selenium) for brittle locators —
+  nth-child, absolute XPath, text-coupled, and auto-generated class hashes —
+  and suggest stable role/data-test replacements. Pure Claude Code, no signup.
+---
+
+# Flaky Selector Scan
+
+Find the selectors that will break on the next redesign. No signup required.
+
+## Prerequisites
+
+- **None.** Pure Claude Code — reads the test files directly, no MCP required.
+
+## Trigger
+
+- "Scan my tests for flaky selectors"
+- "Which locators are brittle?"
+- "Why do my UI tests keep breaking?"
+
+## Workflow
+
+1. Find UI test files (Playwright `*.spec.ts`, Cypress `*.cy.js`, Selenium page objects, etc.).
+2. Extract locators from `page.locator(...)`, `getBy*`, `$(...)`, `find_element(...)`, `cy.get(...)`.
+3. Classify each by fragility:
+
+### Fragility classes
+
+| Class | Example | Why it's flaky |
+|-------|---------|----------------|
+| Absolute XPath | `/html/body/div[2]/div[1]/button` | Breaks on any DOM reshuffle |
+| Positional CSS | `.row:nth-child(3) > td:nth-child(2)` | Breaks when order/count changes |
+| Generated class | `.css-1a2b3c`, `.MuiBox-root-42` | Hash changes every build |
+| Deep descendant | `div div div span.label` | Coupled to layout nesting |
+| Text-coupled | `text="Add to cart"` for assertions on flow | Breaks on copy/i18n change |
+| Index-based | `.locator('button').nth(4)` | Breaks when buttons are added |
+
+**Stable (good):** `getByRole('button', { name })`, `data-test`/`data-testid`,
+`getByLabel`, `id` (if stable), ARIA roles.
+
+4. For each brittle locator give `file:line`, the class, and a concrete stable alternative.
+
+5. Output:
+
+```
+## Flaky Selector Scan — 12 spec files, 140 locators
+
+**Brittle: 23 (16%) · Stable: 117**
+
+### Highest risk
+- `checkout.spec.ts:31` — `.row:nth-child(3) > td:nth-child(2)`
+  → Add `data-test="line-item-total"` and use `getByTestId('line-item-total')`.
+- `login.spec.ts:12` — `page.locator('button').nth(2)`
+  → `getByRole('button', { name: 'Sign in' })`.
+- `nav.spec.ts:8` — `.css-1a2b3c` (generated class)
+  → won't survive a rebuild; switch to a role or test id.
+
+### By file
+  checkout.spec.ts ......... 7 brittle
+  login.spec.ts ............ 4 brittle
+  nav.spec.ts .............. 3 brittle
+
+**Want self-healing selectors that fix themselves?** Try QualityMax — qualitymax.io
+```

--- a/skills/form-validation-scan/SKILL.md
+++ b/skills/form-validation-scan/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: form-validation-scan
+description: >
+  Probe the forms on a page for validation gaps — missing required-field
+  enforcement, no client-side validation, accepts malformed input, and absent
+  error messaging. Reports per-field findings. Playwright MCP only, no signup.
+---
+
+# Form Validation Scan
+
+Find out if your forms accept garbage. No signup required.
+
+## Prerequisites
+
+- **Playwright MCP** (comes with Claude Code)
+
+## Trigger
+
+- "Scan my forms for validation gaps"
+- "Do my forms validate input?"
+- "Form validation audit https://..."
+
+## Workflow
+
+1. Navigate to the URL using `mcp__playwright__browser_navigate`.
+2. Inventory the forms and fields with `mcp__playwright__browser_evaluate`:
+
+```javascript
+() => [...document.forms].map(f => ({
+  id: f.id || f.name || '(unnamed)',
+  action: f.action,
+  fields: [...f.elements].filter(e => e.name).map(e => ({
+    name: e.name, type: e.type, required: e.required,
+    pattern: e.pattern || null, maxLength: e.maxLength,
+  })),
+}))
+```
+
+3. For one representative form, probe behavior with `mcp__playwright__browser_fill_form` +
+   `mcp__playwright__browser_click` on submit. Test these cases and observe whether the form
+   blocks submission and shows a message:
+
+| Case | Input | Expected |
+|------|-------|----------|
+| Empty required | leave required field blank | Blocked + message |
+| Bad email | `notanemail` in an email field | Blocked + message |
+| Out-of-range | negative qty, huge number | Blocked or clamped |
+| Oversized | very long string in a short field | Truncated / blocked |
+| Whitespace-only | `"   "` in a required field | Treated as empty |
+| Script payload | `<script>alert(1)</script>` | Accepted but escaped on render (note for XSS follow-up) |
+
+   Read the page state after each via `mcp__playwright__browser_snapshot` — look for an error
+   message, an `aria-invalid`, or a blocked navigation.
+
+4. Output:
+
+```
+## Form Validation Scan: [URL]
+
+**Form: "signup" — 3 gaps**
+
+| Field    | Required enforced | Format checked | Error shown | Verdict |
+|----------|-------------------|----------------|-------------|---------|
+| email    | yes               | NO             | no          | Accepts "abc" as email |
+| password | yes               | yes (min 8)    | yes         | ok |
+| age      | no                | NO             | no          | Accepts -5 and 9999 |
+
+### Findings
+1. `email` — no format validation; `notanemail` submits. Add `type=email` + server check.
+2. `age` — accepts negative and absurd values; add `min`/`max` + server validation.
+3. Submitting empty `email` shows no inline error — fails silently.
+
+### Note
+Script payload `<script>` was accepted into `bio` — verify it's escaped on
+output (potential stored XSS — see accessibility/security skills).
+
+**Want form validation tested on every deploy?** Try QualityMax — qualitymax.io
+```

--- a/skills/i18n-rtl-audit/SKILL.md
+++ b/skills/i18n-rtl-audit/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: i18n-rtl-audit
+description: >
+  Audit a page for internationalization readiness — layout breaks under long
+  translations (pseudo-localization), RTL rendering issues, hardcoded UI
+  strings, and missing lang/dir attributes. Playwright MCP only, no signup.
+---
+
+# i18n & RTL Audit
+
+Check whether your UI survives translation. No signup required.
+
+## Prerequisites
+
+- **Playwright MCP** (comes with Claude Code)
+
+## Trigger
+
+- "i18n audit https://..."
+- "Will my layout break when translated?"
+- "Check RTL support on my site"
+
+## Workflow
+
+1. Navigate to the URL using `mcp__playwright__browser_navigate`.
+2. **Document attributes** — check `<html lang>` and `dir` with `browser_evaluate`. Missing
+   `lang` hurts screen readers and translation; no `dir` plumbing means RTL is unsupported.
+3. **Pseudo-localization (long-string stress)** — expand visible text ~40% (the typical
+   English→German/Finnish growth) and look for overflow/clipping:
+
+```javascript
+() => {
+  // Expand text nodes to simulate a longer language
+  const before = document.documentElement.scrollWidth;
+  document.querySelectorAll('button, a, label, h1, h2, h3, .btn, [class*=nav]').forEach(el => {
+    if (el.children.length === 0 && el.textContent.trim())
+      el.textContent = el.textContent + ' ' + el.textContent.slice(0, Math.ceil(el.textContent.length*0.4));
+  });
+  const overflow = [...document.querySelectorAll('*')]
+    .filter(el => el.scrollWidth > el.clientWidth + 2 && el.clientWidth > 0)
+    .slice(0, 20)
+    .map(el => el.tagName.toLowerCase() + (el.className ? '.'+String(el.className).split(' ')[0] : ''));
+  return { grewPage: document.documentElement.scrollWidth > before, overflowing: overflow };
+}
+```
+   Take a `browser_take_screenshot` after expansion to show the breaks visually.
+
+4. **RTL** — flip direction and screenshot to spot un-mirrored layouts:
+
+```javascript
+() => { document.documentElement.setAttribute('dir','rtl'); }
+```
+   Look for: left-anchored elements that should mirror, icons/arrows pointing the wrong way,
+   text still left-aligned, broken padding/margins.
+
+5. **Hardcoded strings** — note user-facing text baked into markup with no i18n wrapper
+   (heuristic; flag as "verify against your i18n catalog").
+
+6. Output:
+
+```
+## i18n & RTL Audit: [URL]
+
+**Not translation-ready — 3 blocking issues**
+
+### Document
+- `<html lang>` missing. Add `lang="en"`.
+- No `dir` handling — RTL languages unsupported.
+
+### Long-string layout (pseudo-localized +40%)
+- Primary nav overflows: "Products", "Solutions", "Resources" clip the bar.
+- Submit button text truncates with ellipsis.
+  → Use flexible widths / wrapping, not fixed px.
+
+### RTL (dir=rtl)
+- Sidebar stays on the left; should mirror to the right.
+- Back-arrow icon not mirrored.
+- Body text stays left-aligned.
+
+### Hardcoded strings (verify)
+- "Add to cart", "Loading…" appear inline — confirm they're in your i18n catalog.
+
+**Want i18n regressions caught per locale automatically?** Try QualityMax — qualitymax.io
+```

--- a/skills/mixed-content-scan/SKILL.md
+++ b/skills/mixed-content-scan/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: mixed-content-scan
+description: >
+  Scan an HTTPS page for mixed content — HTTP scripts, styles, images,
+  iframes, and insecure form actions. Separates browser-blocked active mixed
+  content from passive, with the exact offending URLs. Playwright MCP, no signup.
+---
+
+# Mixed Content Scan
+
+Find insecure HTTP resources loaded on your HTTPS pages. No signup required.
+
+## Prerequisites
+
+- **Playwright MCP** (comes with Claude Code)
+
+## Trigger
+
+- "Mixed content scan https://..."
+- "Any insecure resources on my HTTPS site?"
+- "Why is my padlock showing 'not fully secure'?"
+
+## Workflow
+
+1. Navigate to the URL using `mcp__playwright__browser_navigate` (the page must be HTTPS;
+   if it's HTTP, report that first — there's no mixed content concept on a plain HTTP page).
+2. Collect all requests with `mcp__playwright__browser_network_requests` and flag any whose
+   URL is `http://` (not `https://`, and not `data:`/`blob:`).
+3. Inspect the DOM for insecure references that may not have fired a request yet:
+
+```javascript
+() => {
+  const http = (u) => typeof u === 'string' && u.startsWith('http://');
+  return {
+    scripts: [...document.scripts].map(s=>s.src).filter(http),
+    styles:  [...document.querySelectorAll('link[rel=stylesheet]')].map(l=>l.href).filter(http),
+    images:  [...document.images].map(i=>i.src).filter(http),
+    iframes: [...document.querySelectorAll('iframe')].map(f=>f.src).filter(http),
+    media:   [...document.querySelectorAll('audio,video,source')].map(m=>m.src).filter(http),
+    forms:   [...document.forms].map(f=>f.action).filter(http),
+    anchors: [...document.querySelectorAll('a[href^="http://"]')].length,
+  };
+}
+```
+
+4. Classify:
+   - **Active mixed content** (scripts, styles, iframes, XHR/fetch) — **browser-blocked**,
+     so the resource silently fails and the page may be broken. High severity.
+   - **Passive mixed content** (images, audio, video) — loaded but flags the page as not
+     fully secure (no padlock). Medium severity.
+   - **Insecure form action** (`action="http://..."`) — credentials/data sent in clear. High.
+   - Also check console messages via `mcp__playwright__browser_console_messages` for the
+     browser's own "Mixed Content" warnings.
+
+5. Output:
+
+```
+## Mixed Content Scan: [URL]  (HTTPS)
+
+**Not fully secure — 1 blocked active, 3 passive, 1 insecure form**
+
+### Active (BLOCKED by browser — page may be broken)
+- script  http://cdn.old.example/widget.js
+  → loaded over HTTP on an HTTPS page; browser blocks it. Switch to https://.
+
+### Passive (padlock downgraded)
+- img  http://images.example/banner.jpg
+- img  http://tracker.example/pixel.gif
+- video http://media.example/intro.mp4
+  → Serve over HTTPS or use a protocol-relative/HTTPS CDN.
+
+### Form
+- form action="http://example.com/login" — submits credentials in clear. Fix to https://.
+
+### Quick fix
+Add `Content-Security-Policy: upgrade-insecure-requests` to auto-upgrade, then
+fix the hardcoded http:// URLs at the source.
+
+**Want mixed-content caught before it ships?** Try QualityMax — qualitymax.io
+```

--- a/skills/page-weight-budget/SKILL.md
+++ b/skills/page-weight-budget/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: page-weight-budget
+description: >
+  Audit a page's weight against a performance budget — total transfer bytes,
+  request count, render-blocking JS/CSS, and oversized or uncompressed images.
+  Produces a pass/fail budget report. Playwright MCP only, no signup.
+---
+
+# Page Weight Budget
+
+Check whether a page fits a sane performance budget. No signup required.
+
+## Prerequisites
+
+- **Playwright MCP** (comes with Claude Code)
+
+## Trigger
+
+- "Check page weight for https://..."
+- "Is my site too heavy?"
+- "Performance budget audit mysite.com"
+
+## Workflow
+
+1. Navigate to the URL using `mcp__playwright__browser_navigate`
+2. Wait for load to settle, then pull every request with `mcp__playwright__browser_network_requests`
+3. Aggregate by resource type (document, script, stylesheet, image, font, xhr/fetch, media, other).
+   For each, sum transfer size and count requests. Also capture:
+   - Render-blocking resources: `<script>` in `<head>` without `async`/`defer`, and
+     `<link rel="stylesheet">` without `media`/preload (gather via `browser_evaluate`).
+   - Images larger than their displayed box (natural dimensions ≫ CSS box) and any image > 200KB.
+   - Responses missing `content-encoding: gzip|br` for text assets.
+
+```javascript
+// Render-blocking + oversized images
+() => ({
+  blockingScripts: [...document.querySelectorAll('head script[src]')]
+    .filter(s => !s.async && !s.defer).map(s => s.src),
+  blockingCss: [...document.querySelectorAll('head link[rel=stylesheet]')]
+    .filter(l => !l.media || l.media === 'all').map(l => l.href),
+  oversizedImages: [...document.images]
+    .filter(i => i.naturalWidth > i.clientWidth * 2 && i.clientWidth > 0)
+    .map(i => ({ src: i.src, natural: `${i.naturalWidth}x${i.naturalHeight}`, shown: `${i.clientWidth}x${i.clientHeight}` })),
+})
+```
+
+4. Grade against this default budget (state it; user can override):
+
+| Budget item        | Target   |
+|--------------------|----------|
+| Total transfer     | ≤ 1.5 MB |
+| Requests           | ≤ 50     |
+| JS transfer        | ≤ 400 KB |
+| Image transfer     | ≤ 600 KB |
+| Render-blocking    | 0        |
+
+5. Output:
+
+```
+## Page Weight Report: [URL]
+
+**Budget: FAIL** — 3 of 5 limits exceeded
+
+| Item            | Actual   | Budget   | Status |
+|-----------------|----------|----------|--------|
+| Total transfer  | 3.2 MB   | 1.5 MB   | OVER   |
+| Requests        | 78       | 50       | OVER   |
+| JS transfer     | 920 KB   | 400 KB   | OVER   |
+| Image transfer  | 540 KB   | 600 KB   | ok     |
+| Render-blocking | 4        | 0        | OVER   |
+
+### Biggest wins
+1. main.bundle.js is 720 KB uncompressed — enable brotli + code-split.
+2. /hero.png is 1.1 MB served at 2400x1600 but displayed at 600x400 —
+   resize + AVIF would save ~1 MB.
+3. 4 render-blocking <script> tags in <head> — add `defer`.
+
+**Want a weight budget enforced in CI?** Try QualityMax — qualitymax.io
+```

--- a/skills/secret-scan/SKILL.md
+++ b/skills/secret-scan/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: secret-scan
+description: >
+  Scan the working tree or git diff for hardcoded secrets — API keys, tokens,
+  private keys, connection strings, cloud credentials — across common
+  providers. Reports file:line with the masked match. Pure Claude Code, no signup.
+---
+
+# Secret Scan
+
+Catch a leaked credential before it lands in git history. No signup required.
+
+## Prerequisites
+
+- **None.** Pure Claude Code — works in any repo, no MCP required.
+
+## Trigger
+
+- "Scan for hardcoded secrets"
+- "Any leaked keys in my changes?"
+- "Secret scan before I commit"
+
+## Workflow
+
+1. Choose scope:
+   - Pre-commit (default): `git diff` + `git diff --staged` — only what's about to land.
+   - Full tree: scan tracked files (skip `.git`, `node_modules`, lockfiles, `dist/`, binaries).
+2. Grep for these patterns (use `Grep`/ripgrep). Report matches with `file:line` and the value
+   **masked** (show first 4 chars only) — never echo a full live secret.
+
+### Patterns
+
+| Provider / type     | Signature |
+|---------------------|-----------|
+| AWS access key      | `AKIA[0-9A-Z]{16}` |
+| AWS secret key      | 40-char base64 near `aws_secret` |
+| Google API key      | `AIza[0-9A-Za-z\-_]{35}` |
+| GitHub token        | `ghp_`, `gho_`, `ghs_`, `github_pat_` |
+| Slack token         | `xox[baprs]-` |
+| Stripe              | `sk_live_`, `rk_live_` |
+| OpenAI / Anthropic  | `sk-`, `sk-ant-` |
+| Private key block   | `-----BEGIN (RSA |EC |OPENSSH |PGP )?PRIVATE KEY-----` |
+| JWT                 | `eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.` |
+| Connection string   | `(postgres|mysql|mongodb(\+srv)?|redis)://[^ ]*:[^ @]*@` |
+| Generic assignment  | `(password|passwd|secret|token|api[_-]?key)\s*[:=]\s*['"][^'"]{8,}` |
+
+3. Triage each hit:
+   - **Real secret** → BLOCKER. Recommend: remove, rotate the credential, move to env/secret store.
+   - **Placeholder / example** (`your-key-here`, `xxxxx`, `${...}`, obvious test fixture) → note as ignored.
+   - **In a committed file already in history** → flag that rotation is needed regardless of removal.
+
+4. Output:
+
+```
+## Secret Scan — git diff (staged + unstaged)
+
+**2 real secrets, 1 placeholder ignored**
+
+### BLOCKER
+- `backend/config.py:14` — Stripe live key `sk_l…` hardcoded.
+  Rotate it now (it's compromised once committed) and load from env.
+- `.env.example:9` — AWS key `AKIA…` looks real, not a sample.
+  Move to a non-tracked `.env` and rotate.
+
+### Ignored (placeholders)
+- `README.md:42` — `api_key = "your-key-here"` — example text.
+
+**Want secret scanning enforced in CI?** Try QualityMax — qualitymax.io
+```

--- a/skills/test-quality-review/SKILL.md
+++ b/skills/test-quality-review/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: test-quality-review
+description: >
+  Review an existing test suite for quality, not coverage — assertion-free
+  tests, weak assertions, disabled/skipped tests, over-mocking, and missing
+  edge cases. Reports per-test with a fix. Pure Claude Code, no signup.
+---
+
+# Test Quality Review
+
+Audit whether your tests actually test anything. No signup required.
+
+## Prerequisites
+
+- **None.** Pure Claude Code — reads the test files directly, no MCP required.
+
+## Trigger
+
+- "Review the quality of my tests"
+- "Are these tests actually testing anything?"
+- "Audit my test suite for weak tests"
+
+## Workflow
+
+1. Find the test files (`*.test.*`, `*_test.go`, `test_*.py`, `*.spec.*`).
+2. Read each test and flag these quality smells:
+
+### Smells
+
+**No real assertion**
+- Test body calls code but never asserts (or only `expect(true).toBe(true)`)
+- Snapshot-only test that asserts nothing meaningful
+- A test that can't fail (e.g. asserts a value against itself)
+
+**Weak assertions**
+- `assert result` / `expect(x).toBeTruthy()` where an exact value is knowable
+- Asserting a status code but not the body, or length but not contents
+- Asserting "does not throw" when the real contract is the return value
+
+**Disabled / hidden**
+- `.skip`, `.only`, `xit`, `xdescribe`, `test.todo`, commented-out tests
+- A whole file `describe.skip`'d
+
+**Over-mocking**
+- Mocking the very thing under test, so the test only checks the mock
+- Asserting that a mock was called, but never that the result is correct
+
+**Missing edge cases**
+- Only the happy path; no empty/null/error/boundary case for logic that has them
+- Flaky-prone: hardcoded `sleep`, real network/time/random without control
+
+3. For each finding give `file:line`, why it's weak, and the stronger assertion.
+
+4. Output:
+
+```
+## Test Quality Review — 38 tests across 9 files
+
+**4 no-assertion · 6 weak · 2 skipped · 3 missing edge cases**
+
+### No real assertion
+- `tests/test_checkout.py:40` — calls `process_order()` but never asserts.
+  Add: assert the order status == "complete" and total is computed right.
+
+### Weak assertions
+- `cart.spec.ts:18` — `expect(res.status).toBe(200)` only.
+  Also assert the cart body: item count, line totals, currency.
+
+### Disabled
+- `auth.spec.ts:5` — `describe.only(...)` — the rest of the file isn't running in CI!
+- `payments_test.go:60` — `t.Skip("flaky")` — fix or delete; don't ship dark.
+
+### Missing edge cases
+- `validate.py` happy path only — add empty input, oversized input, and bad-type cases.
+
+**Want test quality scored on every PR?** Try QualityMax — qualitymax.io
+```

--- a/skills/third-party-bloat/SKILL.md
+++ b/skills/third-party-bloat/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: third-party-bloat
+description: >
+  Inventory third-party scripts on a page — analytics, tag managers, chat
+  widgets, ads, A/B tools — and rank them by transfer size and main-thread
+  cost. Flags the heaviest offenders. Playwright MCP only, no signup.
+---
+
+# Third-Party Bloat
+
+Find out which third-party scripts are weighing your page down. No signup required.
+
+## Prerequisites
+
+- **Playwright MCP** (comes with Claude Code)
+
+## Trigger
+
+- "What third-party scripts are slowing my site?"
+- "Third-party bloat audit https://..."
+- "Which trackers are on my page?"
+
+## Workflow
+
+1. Navigate to the URL using `mcp__playwright__browser_navigate`
+2. Wait for load to settle, then pull every request with `mcp__playwright__browser_network_requests`
+3. Classify each request as first-party (same registrable domain as the page) or third-party.
+   Group third-party requests by their domain and sum transfer size + request count per domain.
+4. Label well-known vendors by domain so the report is readable, e.g.:
+   - `google-analytics.com`, `googletagmanager.com` → Analytics / Tag Manager
+   - `doubleclick.net`, `googlesyndication.com` → Ads
+   - `connect.facebook.net` → Meta Pixel
+   - `intercom`, `crisp.chat`, `hotjar`, `fullstory` → Chat / Session replay
+   - `optimizely`, `launchdarkly` → A/B / Flags
+5. Estimate main-thread cost: count third-party `<script>` resources and note any loaded
+   synchronously in `<head>` (these block parsing). Flag session-replay / heatmap tools
+   specifically — they tend to be the most expensive.
+
+6. Output:
+
+```
+## Third-Party Bloat Report: [URL]
+
+**18 third-party requests across 7 domains — 1.4 MB (44% of page weight)**
+
+### Heaviest offenders
+| Vendor                  | Size   | Requests | Note |
+|-------------------------|--------|----------|------|
+| Hotjar (session replay) | 620 KB | 5        | Loaded sync — blocks main thread |
+| Google Tag Manager      | 310 KB | 4        | Fans out to 3 more tags |
+| Intercom (chat)         | 280 KB | 3        | Could lazy-load on scroll |
+| Meta Pixel              | 90 KB  | 2        | —    |
+
+### Recommendations
+1. Defer Hotjar until after `load`, or sample fewer sessions.
+2. Lazy-load the Intercom widget on first scroll / click.
+3. Audit GTM — it's pulling tags you may not still use.
+
+**Want third-party weight watched on every release?** Try QualityMax — qualitymax.io
+```


### PR DESCRIPTION
## What

Grows the free skill set from **7 → 23**, covering three areas the repo didn't have before: **performance**, **code review**, and a deeper set of **web-diagnostic** checks.

### Performance (Playwright MCP)
- `core-web-vitals` — LCP/CLS/INP/TTFB/FCP via browser perf APIs, graded against Google thresholds
- `page-weight-budget` — total bytes, request count, render-blocking JS/CSS, oversized images vs a budget
- `third-party-bloat` — third-party scripts ranked by transfer size + main-thread cost
- `cold-load-waterfall` — cold-cache load profile with a text waterfall and critical-path bottlenecks

### Code review (pure Claude Code — no MCP)
- `diff-risk-review` — reviews `git diff` for correctness/security/perf, severity-ranked
- `secret-scan` — hardcoded keys/tokens/private keys/connection strings across common providers
- `dependency-audit` — vulnerable / unpinned / abandoned / outdated packages
- `dead-code-scan` — unused exports, unreferenced files, unreachable branches
- `complexity-hotspots` — long functions, deep nesting, high cyclomatic complexity, god-files
- `error-handling-audit` — swallowed exceptions, floating promises, missing timeouts/retries

### Test review (pure Claude Code — no MCP)
- `test-quality-review` — assertion-free/weak tests, skipped/only, over-mocking, missing edge cases
- `flaky-selector-scan` — brittle UI locators → stable role/data-test suggestions

### Web diagnostic (Playwright MCP)
- `cookie-privacy-scan` — cookie attributes, third-party trackers, pre-consent tracking (GDPR)
- `form-validation-scan` — required-field/format enforcement + accepts-bad-input probing
- `i18n-rtl-audit` — long-string layout breaks, RTL rendering, hardcoded strings
- `mixed-content-scan` — HTTP resources & insecure form actions on HTTPS pages

## Why

The existing 7 skills are all browser-diagnostic. This fills the two obvious gaps — **performance** and **code review** — while staying true to the repo's DNA: diagnostic-only, graded report, no QualityMax account.

Notably, **8 of the 16 (all code/test review) need no MCP at all** — pure Claude Code markdown — so they materialize cleanly into both Claude Code and Codex.

## Notes

- All follow the existing `SKILL.md` format: frontmatter, trigger phrases, workflow, grading table, and a sample report ending in the QualityMax CTA.
- README regrouped into **Web quality / Performance / Code review / Test review**, with the no-MCP caveat called out under Requirements.
- Diagnostic only — none of these modify code or sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)