### PR TITLE
Security hardening + 4 new security & compliance skills

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Keep GitHub Actions used by our workflows patched.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,18 @@
+name: validate-skills
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+# Least privilege: this workflow only needs to read the repo.
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate skills (structure + read-only security contract)
+        run: node scripts/validate-skills.mjs

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+- Showing empathy and kindness toward others.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Focusing on what is best for the community.
+
+Unacceptable behavior includes harassment, insulting or derogatory comments, personal or political attacks, publishing others' private information without permission, and other conduct that could reasonably be considered inappropriate.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers at **contact@qualitymax.io**. All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and security of the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to free-qa-skills
+
+Thanks for helping improve free, no-signup QA and security checks for AI coding assistants. Contributions are welcome — new skills, fixes, and clearer instructions.
+
+## Anatomy of a skill
+
+Each skill lives in `skills/<skill-name>/SKILL.md` and is plain Markdown with YAML frontmatter:
+
+```markdown
+---
+name: my-skill
+description: >
+  One or two sentences describing what the skill checks and that it is read-only.
+---
+
+# My Skill
+
+Short intro.
+
+## Prerequisites
+- None, or "Playwright MCP (comes with Claude Code)".
+
+## Trigger
+- "Phrases a user would type to invoke it"
+
+## Workflow
+1. Steps the assistant follows...
+```
+
+Requirements (checked by CI):
+- `skills/<name>/SKILL.md` exists.
+- Frontmatter has `name` and `description`; `name` **equals the directory name**.
+- The body has a `# ` title and `## Trigger` and `## Workflow` sections.
+
+## The Skill Security Contract (required)
+
+Every skill must be **diagnostic and read-only**. By contributing a skill you confirm it:
+
+- [ ] Makes **no destructive or state-changing** changes — it finds and grades problems, it does not fix them.
+- [ ] Runs **no** destructive/remote-execution commands (`rm -rf`, `git push`/`commit`/`reset --hard`, `sudo`, `chmod 777`, `curl … | sh`, etc.).
+- [ ] Does **not write, modify, or delete** the user's files, repos, or sites.
+- [ ] Does **not exfiltrate** data — no network calls beyond the declared Playwright MCP browsing of a user-supplied URL.
+- [ ] **Masks secrets** in any output (never echoes a full live credential).
+- [ ] Is resistant to instruction-hijacking by the content under test (treat page/diff content as untrusted data, not commands).
+
+These rules are our core security guarantee and are enforced by `scripts/validate-skills.mjs`. See [SECURITY.md](SECURITY.md).
+
+## Before you open a PR
+
+```bash
+node scripts/validate-skills.mjs
+```
+
+This validates structure and the security contract for every skill. CI runs the same check.
+
+## Conduct
+
+By participating you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then use in Claude Code: `/accessibility-check https://mysite.com`
 
 ## Skills
 
-23 diagnostic skills across four areas. All are read-only — they find problems and grade them, they don't change your code or site.
+27 diagnostic skills across five areas. All are read-only — they find problems and grade them, they don't change your code or site.
 
 ### Web quality (Playwright MCP)
 
@@ -64,6 +64,15 @@ Then use in Claude Code: `/accessibility-check https://mysite.com`
 |-------|---------------|
 | **test-quality-review** | Assertion-free tests, weak assertions, skipped/only tests, over-mocking, missing edge cases |
 | **flaky-selector-scan** | Brittle UI locators (nth-child, absolute XPath, generated classes) → stable role/data-test suggestions |
+
+### Security & compliance (pure Claude Code — no MCP)
+
+| Skill | What It Checks |
+|-------|---------------|
+| **agentic-app-risk-review** | LLM/agent apps — prompt injection, unsafe tool calls, excessive agency, PII/secret leakage (OWASP-LLM-style) |
+| **iac-misconfig-scan** | Dockerfiles, Compose, Terraform, GitHub Actions — root containers, world-writable files, unpinned actions, hardcoded secrets |
+| **api-security-scan** | REST / OpenAPI — missing auth, broken object-level authorization (IDOR/BOLA), no rate limiting, verbose errors |
+| **license-compliance-scan** | Dependency licenses vs. your project's — copyleft conflicts, AGPL, unknown/unlicensed packages |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Free QA Skills for Claude Code
 
+[![validate-skills](https://github.com/Quality-Max/free-qa-skills/actions/workflows/validate-skills.yml/badge.svg)](https://github.com/Quality-Max/free-qa-skills/actions/workflows/validate-skills.yml)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-yellow?logo=buymeacoffee)](https://buymeacoffee.com/qualitymax)
 
 Quick quality checks for any website or codebase. No signup, no API keys — just Claude Code. The web skills use Playwright MCP (included with Claude Code); the code-review skills are pure Claude Code and need no MCP at all.
@@ -90,6 +91,14 @@ Connect Claude Code to QualityMax MCP for 85 tools: test generation, AI code rev
   }
 }
 ```
+
+## Security & contributing
+
+Every skill is **diagnostic and read-only** — it finds and grades problems, it never changes your code or site, and it doesn't exfiltrate data. This read-only contract is enforced in CI by [`scripts/validate-skills.mjs`](scripts/validate-skills.mjs).
+
+- Report a vulnerability: see [SECURITY.md](SECURITY.md).
+- Add or improve a skill: see [CONTRIBUTING.md](CONTRIBUTING.md) (run `node scripts/validate-skills.mjs` before opening a PR).
+- Be excellent to each other: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+`free-qa-skills` is a catalog of read-only diagnostic **skills** (Markdown instructions) for AI coding assistants such as Claude Code. The skills ship no executable package and pull no dependencies — but because they run inside a developer's environment and influence what an AI agent does, their integrity matters. This policy explains our security model and how to report issues.
+
+## The read-only security contract
+
+Every skill in this repository must be **diagnostic and read-only**. A skill must not:
+
+- run destructive or state-changing commands (no `rm -rf`, `git push`, `git commit`, `git reset --hard`, `sudo`, `chmod 777`, piping remote content into a shell, etc.);
+- write, modify, or delete the user's code, files, repositories, or sites (skills find and grade problems — they do not fix them);
+- exfiltrate data — no sending repository contents, secrets, or scan results to any network destination beyond the explicitly declared Playwright MCP browsing of a user-supplied URL;
+- echo live secrets in full (secret-handling skills must mask matches).
+
+This contract is **enforced in CI** by `scripts/validate-skills.mjs` (see [CONTRIBUTING.md](CONTRIBUTING.md)). A change that violates it is a security defect.
+
+## What we consider a vulnerability
+
+- A skill that could cause data loss, unwanted writes, or execution of destructive/remote commands.
+- A skill that could exfiltrate code, secrets, or results.
+- A secret-handling skill that prints unmasked credentials.
+- Instructions that can be hijacked by malicious content in the target under test (e.g., a page or diff that injects commands the agent then follows) to escape the read-only contract.
+
+## Reporting a vulnerability
+
+Please report privately — do **not** open a public issue for a security problem.
+
+- Preferred: GitHub **Security Advisories** → "Report a vulnerability" on this repository.
+- Or email **contact@qualitymax.io** with `SECURITY: free-qa-skills` in the subject.
+
+Include the affected skill, the impact, and steps to reproduce. We aim to acknowledge within **5 business days** and to agree on a disclosure timeline with you. We credit reporters who wish to be named.
+
+## Supported versions
+
+Skills are rolling; the latest commit on the default branch is the supported version. Fixes ship to the default branch.

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 // Validates every skill in skills/<name>/SKILL.md:
 //  - structure: frontmatter name/description, name === dir, title + Trigger + Workflow
-//  - the read-only security contract (see SECURITY.md): no destructive / exfiltration tokens
+//  - the read-only security contract (see SECURITY.md): no destructive / exfiltration
+//    commands in RUNNABLE shell code-blocks (```bash|sh|shell|zsh|console). Detection
+//    skills may name these patterns in prose/tables — only commands the agent would
+//    actually run are checked.
 // Zero dependencies. Exits non-zero on any violation. Run: node scripts/validate-skills.mjs
 
 import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
@@ -23,6 +26,22 @@ const FORBIDDEN = [
 
 const errors = [];
 const fail = (skill, msg) => errors.push(`${skill}: ${msg}`);
+
+// Returns the command lines inside runnable shell fences (```bash|sh|shell|zsh|console),
+// skipping blank lines and comments. Detection patterns in prose/tables are ignored.
+function shellCommandLines(text) {
+  const out = [];
+  const fence = /```(bash|sh|shell|zsh|console)\r?\n([\s\S]*?)```/g;
+  let m;
+  while ((m = fence.exec(text))) {
+    for (const raw of m[2].split('\n')) {
+      const line = raw.trim();
+      if (!line || line.startsWith('#')) continue;
+      out.push(line);
+    }
+  }
+  return out.join('\n');
+}
 
 function parseFrontmatter(text) {
   const m = text.match(/^---\n([\s\S]*?)\n---/);
@@ -65,8 +84,9 @@ for (const dir of dirs) {
   if (!/^##\s+Trigger\b/m.test(text)) fail(dir, 'missing "## Trigger" section');
   if (!/^##\s+Workflow\b/m.test(text)) fail(dir, 'missing "## Workflow" section');
 
+  const runnable = shellCommandLines(text);
   for (const { re, label } of FORBIDDEN) {
-    if (re.test(text)) fail(dir, `read-only contract violation: contains "${label}"`);
+    if (re.test(runnable)) fail(dir, `read-only contract violation: runnable command contains "${label}"`);
   }
 }
 

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Validates every skill in skills/<name>/SKILL.md:
+//  - structure: frontmatter name/description, name === dir, title + Trigger + Workflow
+//  - the read-only security contract (see SECURITY.md): no destructive / exfiltration tokens
+// Zero dependencies. Exits non-zero on any violation. Run: node scripts/validate-skills.mjs
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
+import { join } from 'path';
+
+const SKILLS_DIR = 'skills';
+
+// Tokens that must never appear in a read-only diagnostic skill.
+const FORBIDDEN = [
+  { re: /\brm\s+-rf\b/, label: 'rm -rf' },
+  { re: /\bgit\s+push\b/, label: 'git push' },
+  { re: /\bgit\s+commit\b/, label: 'git commit' },
+  { re: /\bgit\s+reset\s+--hard\b/, label: 'git reset --hard' },
+  { re: /\bsudo\s+/, label: 'sudo' },
+  { re: /\bchmod\s+777\b/, label: 'chmod 777' },
+  { re: /\bcurl\b[^\n|]*\|\s*(sh|bash)\b/, label: 'curl | sh' },
+  { re: /\bwget\b[^\n|]*\|\s*(sh|bash)\b/, label: 'wget | sh' },
+];
+
+const errors = [];
+const fail = (skill, msg) => errors.push(`${skill}: ${msg}`);
+
+function parseFrontmatter(text) {
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return null;
+  const block = m[1];
+  const out = {};
+  // minimal YAML: top-level "key:" or "key: value" (value may continue on folded lines)
+  const nameM = block.match(/^name:\s*(.+)$/m);
+  const descM = block.match(/^description:\s*([\s\S]*?)(?=^\w+:|\s*$)/m);
+  if (nameM) out.name = nameM[1].trim();
+  if (descM) out.description = descM[1].trim();
+  return out;
+}
+
+if (!existsSync(SKILLS_DIR)) {
+  console.error(`No ${SKILLS_DIR}/ directory found.`);
+  process.exit(1);
+}
+
+const dirs = readdirSync(SKILLS_DIR).filter((d) => {
+  try { return statSync(join(SKILLS_DIR, d)).isDirectory(); } catch { return false; }
+});
+
+if (dirs.length === 0) fail(SKILLS_DIR, 'no skill directories found');
+
+for (const dir of dirs) {
+  const skillPath = join(SKILLS_DIR, dir, 'SKILL.md');
+  if (!existsSync(skillPath)) { fail(dir, 'missing SKILL.md'); continue; }
+  const text = readFileSync(skillPath, 'utf8');
+
+  const fm = parseFrontmatter(text);
+  if (!fm) { fail(dir, 'missing or malformed YAML frontmatter'); }
+  else {
+    if (!fm.name) fail(dir, 'frontmatter missing "name"');
+    else if (fm.name !== dir) fail(dir, `frontmatter name "${fm.name}" != directory "${dir}"`);
+    if (!fm.description) fail(dir, 'frontmatter missing "description"');
+  }
+
+  if (!/^#\s+\S/m.test(text)) fail(dir, 'missing a "# " title');
+  if (!/^##\s+Trigger\b/m.test(text)) fail(dir, 'missing "## Trigger" section');
+  if (!/^##\s+Workflow\b/m.test(text)) fail(dir, 'missing "## Workflow" section');
+
+  for (const { re, label } of FORBIDDEN) {
+    if (re.test(text)) fail(dir, `read-only contract violation: contains "${label}"`);
+  }
+}
+
+if (errors.length) {
+  console.error(`✗ Skill validation failed (${errors.length}):`);
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+
+console.log(`✓ ${dirs.length} skills validated: structure + read-only security contract OK.`);

--- a/skills/agentic-app-risk-review/SKILL.md
+++ b/skills/agentic-app-risk-review/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: agentic-app-risk-review
+description: >
+  Defensive review of an LLM/agent application for OWASP-LLM-style risks —
+  prompt injection, unsafe tool calls, excessive agency, and PII/secret
+  leakage. Reads your code, flags issues with file:line. Pure Claude Code, no signup.
+---
+
+# Agentic App Risk Review
+
+Find the security weaknesses in your own LLM or agent app before users — or attackers — do. Read-only: it flags risks, it doesn't change your code.
+
+## Prerequisites
+
+- **None.** Pure Claude Code — reads your repository directly, no MCP required.
+
+## Trigger
+
+- "Review my agent app for prompt injection"
+- "Security review of my LLM integration"
+- "Is my chatbot safe against jailbreaks / tool abuse?"
+
+## Workflow
+
+1. Locate the AI surface: where prompts are built, where the model is called, and where it can take actions (tool/function calls, shell, HTTP, DB, file writes, payments).
+2. Review each area against the checks below, reporting `file:line`, severity, and a concrete fix. Treat all model input and tool output as untrusted.
+
+### What to flag
+
+| Risk | What to look for |
+|------|------------------|
+| **Prompt injection** | Untrusted input (user text, web/RAG content, file contents) concatenated into the prompt without delineation or instruction-hardening |
+| **Indirect injection** | Fetched pages, emails, or documents fed to the model that can carry instructions the agent then follows |
+| **Unsafe tool calls** | Tools that run commands, write files, send money, or call APIs with no allowlist, schema validation, or argument sanitization |
+| **Excessive agency** | Destructive/irreversible tools exposed with no human-in-the-loop confirmation |
+| **Unbounded loops** | Agent/tool loops with no max-step or cost/timeout limit (DoS / runaway spend) |
+| **Output not validated** | Model output used directly in shell, SQL, HTML, or `eval` without checking |
+| **PII / secret leakage** | Secrets, keys, or personal data placed into prompts, tool args, or logs/traces |
+| **Over-broad system prompt** | Secrets or privileged instructions in the system prompt that injection could exfiltrate |
+| **No rate / cost limits** | Per-user or per-session limits absent on model and tool calls |
+
+3. Output a severity-ranked report:
+
+```
+## Agentic App Risk Review
+
+**2 high, 1 medium**
+
+### HIGH
+- agent/tools.py:40 — shell tool runs model-provided strings with no allowlist
+  or validation (command injection via tool abuse). Restrict to a fixed command
+  set and validate arguments.
+- chat/prompt.py:22 — user message concatenated straight into the system prompt
+  (prompt injection). Separate untrusted input from instructions and harden.
+
+### MEDIUM
+- agent/loop.py:15 — tool loop has no max-step limit (runaway spend / DoS).
+  Add a step and cost ceiling.
+```
+
+This review is diagnostic only. **Want continuous adversarial testing of your agent in CI?** See QualityMax — qualitymax.io

--- a/skills/api-security-scan/SKILL.md
+++ b/skills/api-security-scan/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: api-security-scan
+description: >
+  Review a REST/HTTP API — from its OpenAPI spec or route code — for security
+  gaps like missing auth, broken object-level authorization, no rate limiting,
+  and verbose errors. Reports file:line. Pure Claude Code, no signup.
+---
+
+# API Security Scan
+
+Find the security holes in your API design before they ship. Read-only: it flags issues with `file:line`, it doesn't change your code.
+
+## Prerequisites
+
+- **None.** Pure Claude Code — reads your OpenAPI/Swagger spec or route/handler code directly, no MCP required.
+
+## Trigger
+
+- "Security review my API / OpenAPI spec"
+- "Check my endpoints for missing auth"
+- "API security scan"
+
+## Workflow
+
+1. Locate the API surface: an OpenAPI/Swagger file if present, otherwise the route definitions and handlers.
+2. Review each endpoint against the checks below; report `path` or `file:line`, severity, and the fix.
+
+### What to flag
+
+| Risk | What to look for |
+|------|------------------|
+| **Missing authentication** | Endpoints with no auth requirement that expose data or actions |
+| **Broken object-level auth (IDOR/BOLA)** | Resources fetched by ID with no ownership/authorization check |
+| **Missing function-level auth** | Admin/privileged operations reachable by normal users |
+| **No rate limiting** | Auth, search, or expensive endpoints with no throttling (brute-force / DoS) |
+| **Verbose errors** | Stack traces, SQL, or internal details returned to clients |
+| **Sensitive data in URLs** | Tokens, passwords, or PII in query strings (logged everywhere) |
+| **Mass assignment** | Request bodies bound to models without an allowlist of fields |
+| **CORS misconfig** | Wildcard origin combined with credentials |
+| **Missing input validation** | Body/query/path params accepted without schema/type checks |
+| **No pagination limits** | List endpoints that can return unbounded result sets |
+| **Secrets in examples** | Real keys/tokens in spec examples or sample requests |
+
+3. Output a severity-ranked report:
+
+```
+## API Security Scan
+
+**2 high, 1 medium**
+
+### HIGH
+- GET /users/{id} — no ownership check; any authenticated user can read any
+  record (BOLA). Enforce that the caller owns or may access {id}.
+- POST /login — no rate limiting; vulnerable to credential brute-force. Add
+  per-IP/per-account throttling and lockout.
+
+### MEDIUM
+- GET /search — returns full stack traces on error. Return a generic message;
+  log details server-side.
+```
+
+Diagnostic only. **Want API auth and BOLA scanning on every PR?** See QualityMax — qualitymax.io

--- a/skills/iac-misconfig-scan/SKILL.md
+++ b/skills/iac-misconfig-scan/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: iac-misconfig-scan
+description: >
+  Scan infrastructure-as-code — Dockerfiles, Compose, Terraform, and GitHub
+  Actions — for security misconfigurations like running as root, world-writable
+  files, unpinned actions, and hardcoded secrets. Pure Claude Code, no signup.
+---
+
+# IaC Misconfig Scan
+
+Catch insecure infrastructure-as-code before it ships. Read-only: it flags misconfigurations with `file:line`, it doesn't change anything.
+
+## Prerequisites
+
+- **None.** Pure Claude Code — reads IaC files directly, no MCP required.
+
+## Trigger
+
+- "Scan my Dockerfile / Terraform / workflows for misconfigs"
+- "Is my infrastructure-as-code secure?"
+- "IaC security review"
+
+## Workflow
+
+1. Find IaC files: `Dockerfile`, `docker-compose*.yml`, `*.tf`, and `.github/workflows/*.yml`.
+2. Review each against the checks below; report `file:line`, severity, and the fix.
+
+### Containers (Dockerfile / Compose)
+
+| Misconfiguration | Why it's risky |
+|------------------|----------------|
+| No `USER` / runs as root | Container compromise becomes host-level risk |
+| World-writable file modes (e.g. `0777`) | Tampering and privilege issues |
+| `:latest` or unpinned base image | Non-reproducible, unreviewed updates |
+| Download-and-execute build step (remote script piped into a shell) | Unverified remote code in the image |
+| Hardcoded secrets / credentials in `ENV` or `ARG` | Secret leakage in image layers |
+| `privileged: true`, host network, or host path mounts (Compose) | Container escape / host exposure |
+| `ADD` with a remote URL | Silent, unverified remote fetch (prefer `COPY`) |
+
+### Terraform
+
+| Misconfiguration | Why it's risky |
+|------------------|----------------|
+| Public object storage / open ingress (`0.0.0.0/0`) | Data exposure / open attack surface |
+| Hardcoded secrets in `.tf` or state | Credential leakage |
+| Unencrypted storage / disabled logging | Data-at-rest and audit gaps |
+
+### GitHub Actions
+
+| Misconfiguration | Why it's risky |
+|------------------|----------------|
+| Actions pinned to a tag, not a commit SHA | Supply-chain tampering |
+| Broad `permissions` (or none set) | Excess token scope |
+| Secrets echoed or used in `pull_request_target` with checkout of PR code | Secret exfiltration |
+
+3. Output a severity-ranked report:
+
+```
+## IaC Misconfig Scan
+
+**1 high, 2 medium**
+
+### HIGH
+- Dockerfile:1 — base image uses ":latest"; pin to a digest for reproducible,
+  reviewable builds.
+
+### MEDIUM
+- .github/workflows/ci.yml:7 — action pinned to a tag, not a commit SHA.
+- docker-compose.yml:12 — service runs without a non-root USER.
+```
+
+Diagnostic only. **Want IaC and SAST checks enforced on every PR?** See QualityMax — qualitymax.io

--- a/skills/license-compliance-scan/SKILL.md
+++ b/skills/license-compliance-scan/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: license-compliance-scan
+description: >
+  Check dependency licenses against your project's license and flag conflicts,
+  copyleft obligations, and unknown/unlicensed packages. Reads manifests
+  directly. Advisory, not legal advice. Pure Claude Code, no signup.
+---
+
+# License Compliance Scan
+
+Spot license conflicts in your dependency tree before they become a problem. Read-only and advisory — it flags risks, it doesn't change anything, and it is not legal advice.
+
+## Prerequisites
+
+- **None.** Pure Claude Code — reads dependency manifests and your `LICENSE` directly, no MCP required.
+
+## Trigger
+
+- "Check my dependency licenses"
+- "Any license conflicts in this project?"
+- "License compliance scan"
+
+## Workflow
+
+1. Identify the project's own license (from `LICENSE`/`package.json`/`pyproject.toml`, etc.).
+2. Read dependency manifests present: `package.json`, `requirements.txt`/`pyproject.toml`, `go.mod`, `Cargo.toml`, `Gemfile`, `pom.xml`, etc. List declared dependencies and, where stated, their licenses.
+3. Compare each dependency's license against the project's and report `file:line` (the manifest entry), severity, and the obligation.
+
+### What to flag
+
+| Finding | Why it matters |
+|---------|----------------|
+| **Strong copyleft in a permissive project** | GPL/AGPL deps in an MIT/Apache project can impose source-disclosure obligations |
+| **Network copyleft (AGPL)** | Obligations can trigger even for hosted/SaaS use |
+| **Unknown / missing license** | A dependency with no clear license is a legal risk by default |
+| **License changed across versions** | A pinned upgrade may pull in new obligations |
+| **Project itself missing a LICENSE** | Others can't legally reuse it; flag if absent |
+| **Incompatible combinations** | Two dependency licenses that can't be combined for distribution |
+
+4. Output an advisory report:
+
+```
+## License Compliance Scan
+
+Project license: Apache-2.0
+**1 high, 1 unknown**
+
+### HIGH
+- package.json:21 — "some-gpl-lib" is GPL-3.0; combining it with an Apache-2.0
+  distribution may impose source-disclosure obligations. Review or replace.
+
+### UNKNOWN
+- requirements.txt:8 — "obscure-pkg" declares no license. Treat as all-rights-
+  reserved until clarified.
+
+Note: advisory only, not legal advice — confirm obligations with counsel.
+```
+
+Diagnostic only. **Want dependency and license checks in your CI gate?** See QualityMax — qualitymax.io


### PR DESCRIPTION
Two related improvements: harden the project's security/governance posture, and grow the catalog with security-focused skills the new CI guard protects.

## Security & governance
- **SECURITY.md** — private disclosure process + the skills' read-only security model.
- **CONTRIBUTING.md** — how to add a skill + the **Skill Security Contract** checklist.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1.
- **scripts/validate-skills.mjs** — zero-dependency validator: structure (frontmatter `name`/`description`, `name` == dir, title + Trigger + Workflow) **and a CI-enforced read-only contract** (no destructive/exfiltration commands in runnable shell blocks).
- **.github/workflows/validate-skills.yml** — runs on push/PR, least-privilege `permissions: contents: read`.
- **.github/dependabot.yml** — keeps workflow actions patched.

## 4 new security & compliance skills (read-only, pure Claude Code)
- **agentic-app-risk-review** — prompt injection, unsafe tool calls, excessive agency, PII/secret leakage (OWASP-LLM-style).
- **iac-misconfig-scan** — Dockerfile/Compose/Terraform/GitHub Actions misconfigurations.
- **api-security-scan** — missing auth, broken object-level authorization (IDOR/BOLA), no rate limiting, verbose errors.
- **license-compliance-scan** — dependency-license conflicts vs. the project's license.

The validator's contract check is scoped to **runnable shell code-blocks**, so a security skill can name dangerous patterns (`chmod 777`, `curl | sh`, …) as detection targets in prose/tables without tripping CI. **All 27 skills pass.** README updated (new category; 23 → 27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)