### PR TITLE
docs: show skills.sh install count

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![validate-skills](https://github.com/Quality-Max/free-qa-skills/actions/workflows/validate-skills.yml/badge.svg)](https://github.com/Quality-Max/free-qa-skills/actions/workflows/validate-skills.yml)
 [![GitHub Agent Skills](https://img.shields.io/badge/GitHub-Agent%20Skills-181717?logo=github)](https://github.com/Quality-Max/free-qa-skills/releases/latest)
-[![skills.sh](https://img.shields.io/badge/skills.sh-install%20skills-blue)](https://www.skills.sh/quality-max/free-qa-skills)
+[![skills.sh installs](https://skills.sh/b/quality-max/free-qa-skills)](https://www.skills.sh/quality-max/free-qa-skills)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-yellow?logo=buymeacoffee)](https://buymeacoffee.com/qualitymax)
 
 Quick QA, accessibility, performance, security, SEO, privacy, and test-review skills for any website or codebase. No signup or API keys required. The web skills use browser automation such as Playwright MCP; the code-review skills work directly with local repository files and need no MCP at all.


### PR DESCRIPTION
## What

Replace the static skills.sh badge with the repository's live skills.sh install count.

## Acceptance criteria

- [x] The README displays the current total installs for `Quality-Max/free-qa-skills`.
- [x] The badge links to the repository's skills.sh directory page.

## Validation

- `node scripts/validate-skills.mjs` — all 27 skills passed structure and read-only security validation.
- `git diff --check` — passed.
- `https://skills.sh/b/quality-max/free-qa-skills` — HTTP 200 SVG; currently reports 115 installs.
- Independent adversarial review — no findings.

## Deployment verification

README-only change. After merge, verify the badge renders on the repository homepage and links to the skills.sh directory page.

## Known unrelated/non-blocking failures

- `pre-commit run --all-files` is not applicable because this repository has no `.pre-commit-config.yaml`.
