### PR TITLE
docs: link additional skill directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Quick QA, accessibility, performance, security, SEO, privacy, and test-review sk
 
 Use these skills when you need a fast audit for Core Web Vitals, WCAG accessibility, broken links, responsive screenshots, console errors, security headers, cookies and trackers, mixed content, dependency risk, leaked secrets, flaky selectors, dead code, API security, IaC misconfigurations, or LLM/agent app risk.
 
-**Directory page:** [skills.sh/quality-max/free-qa-skills](https://www.skills.sh/quality-max/free-qa-skills)
+**Skill directories:** [skills.sh](https://www.skills.sh/quality-max/free-qa-skills), [Smithery](https://smithery.ai/console/skills), and [SkillMD](https://skillmd.com/u/ruslan-strazhnyk).
 
 ## Install
 


### PR DESCRIPTION
## Summary

- link the README to the requested Smithery skills console
- link the README to the requested SkillMD profile
- retain the existing repo-specific skills.sh directory link

## Validation

- `node scripts/validate-skills.mjs` (27 skills passed)
- `git diff --check`
- both added URLs return HTTP 200
- independent adversarial diff review: no findings

`pre-commit run --all-files` is not applicable because this repository has no `.pre-commit-config.yaml`.
